### PR TITLE
python3.11 C API Changes

### DIFF
--- a/src/bchlib.c
+++ b/src/bchlib.c
@@ -31,6 +31,11 @@
 # define alloca(size) _alloca(size)
 #endif
 
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_SIZE)
+static inline void _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
+{ ob->ob_size = size; }
+#define Py_SET_SIZE(ob, size) _Py_SET_SIZE((PyVarObject*)(ob), size)
+#endif
 
 typedef struct {
 	PyObject_HEAD
@@ -141,7 +146,7 @@ BCH_encode(BCHObject *self, PyObject *args, PyObject *kwds)
 	} else {
 		memset(result_ecc->ob_bytes, 0, ecc_bytes);
 	}
-	Py_SIZE(result_ecc) = ecc_bytes;
+	Py_SET_SIZE(result_ecc, ecc_bytes);
 	result_ecc->ob_alloc = ecc_bytes;
 #if PY_MAJOR_VERSION >= 3
 	result_ecc->ob_start = result_ecc->ob_bytes;
@@ -223,7 +228,7 @@ BCH_decode(BCHObject *self, PyObject *args, PyObject *kwds)
 	} else {
 		memcpy(result_data->ob_bytes, data.buf, data.len);
 	}
-	Py_SIZE(result_data) = data.len;
+	Py_SET_SIZE(result_data, data.len);
 	result_data->ob_alloc = data.len;
 #if PY_MAJOR_VERSION >= 3
 	result_data->ob_start = result_data->ob_bytes;
@@ -231,7 +236,7 @@ BCH_decode(BCHObject *self, PyObject *args, PyObject *kwds)
 	result_data->ob_exports = 0;
 
 	memcpy(result_ecc->ob_bytes, ecc.buf, ecc.len);
-	Py_SIZE(result_ecc) = ecc.len;
+	Py_SET_SIZE(result_ecc, ecc.len);
 	result_ecc->ob_alloc = ecc.len;
 #if PY_MAJOR_VERSION >= 3
 	result_ecc->ob_start = result_ecc->ob_bytes;
@@ -418,7 +423,7 @@ BCH_decode_syndromes(BCHObject *self, PyObject *args, PyObject *kwds)
 	} else {
 		memcpy(result_data->ob_bytes, data.buf, data.len);
 	}
-	Py_SIZE(result_data) = data.len;
+	Py_SET_SIZE(result_data, data.len);
 	result_data->ob_alloc = data.len;
 #if PY_MAJOR_VERSION >= 3
 	result_data->ob_start = result_data->ob_bytes;


### PR DESCRIPTION
In python 3.11, since [Py_SIZE()](https://docs.python.org/3/c-api/structures.html#c.Py_SIZE) is changed to a inline static function, Py_SIZE(obj) = new_size must be replaced with Py_SET_SIZE(obj, new_size)

Macro used for backward compatibility.

https://docs.python.org/3/whatsnew/3.11.html#whatsnew311-c-api-porting
